### PR TITLE
Modification exo 04-struct

### DIFF
--- a/corrections/04-struct/src/main.rs
+++ b/corrections/04-struct/src/main.rs
@@ -1,62 +1,75 @@
 // Définition de la struct Car
 struct Car {
-    make: String,
+    brand: String,
     model: String,
     year: u32,
 }
 
 // Implémentation de méthodes pour Car
 impl Car {
+    // Constructeur [optionnel]
+    fn new(brand: String, model: String, year: u32) -> Self {
+        Car { brand, model, year }
+    }
+
+    // Méthode pour décrire l'instance [optionnel]
+    fn describe(&self) -> String {
+        format!("In {}, {} created the {}", self.year, self.brand, self.model)
+    }
+
+    /* DEPRECATED : ne gère pas quand current_year < self.year
     // Méthode pour calculer l'âge de la voiture
     fn car_age(&self, current_year: u32) -> u32 {
         current_year - self.year
     }
 
     // Fonction pour vérifier si la voiture est ancienne
-    fn is_classic(&self, current_year: u32) -> Option<&Car> {
+    fn is_classic(&self, current_year: u32) -> Option<&Self> {
         if self.car_age(current_year) > 10 {
             Some(self)
         } else {
             None
         }
     }
+    */
 
-    // Fonction pour démarrer la voiture
-    fn start_car(&self, battery_ok: bool) -> Result<&Car, String> {
-        if battery_ok {
-            Ok(self)
+    // Méthode pour calculer l'âge de la voiture
+    fn car_age(&self, current_year: u32) -> Result<u32, String> {
+        if current_year < self.year {
+            Err(String::from("Current year cannot be less than the car's year of manufacture."))
         } else {
-            Err(String::from("Cannot start the car: battery is dead"))
+            Ok(current_year - self.year)
         }
+    }
+
+    // Fonction pour vérifier si la voiture est ancienne
+    fn is_classic(&self, current_year: u32) -> Result<bool, String> {
+        let age = self.car_age(current_year)?;
+        Ok(age > 10)
     }
 }
 
 fn main() {
-    let my_car = Car {
-        make: String::from("Toyota"),
-        model: String::from("Corolla"),
-        year: 2010,
-    };
+    let my_car = Car::new(
+        String::from("Fiat"),
+        String::from("Multipla"),
+        1998
+    );
+    println!("{}", my_car.describe());
+    // println!("Age of my car: {}", my_car.car_age(2024));
 
-    // Calcul de l'âge de la voiture
-    let current_year = 2024;
-    println!("Car age: {} years", my_car.car_age(current_year));
+    /* DEPRECATED
+    // Vérifier si la voiture est ancienne
+    match my_car.is_classic(2024) {
+        Some(_car) => println!("This car is a classic!"),
+        None => println!("This car is not a classic.")
+    }
+    */
 
     // Vérifier si la voiture est ancienne
-    match my_car.is_classic(current_year) {
-        Some(car) => println!("The car is a classic: {}", car.model),
-        None => println!("The car is not a classic"),
-    }
-
-    // Démarrer la voiture avec batterie OK
-    match my_car.start_car(true) {
-        Ok(car) => println!("Car started successfully: {}", car.model),
-        Err(e) => println!("Error: {}", e),
-    }
-
-    // Démarrer la voiture avec batterie déchargée
-    match my_car.start_car(false) {
-        Ok(car) => println!("Car started successfully: {}", car.model),
-        Err(e) => println!("Error: {}", e),
+    match my_car.is_classic(2024) {
+        Ok(true) => println!("This car is a classic!"),
+        Ok(false) => println!("This car is not a classic."),
+        Err(e) => println!("Error: {}", e)
     }
 }

--- a/enonces/04-struct.md
+++ b/enonces/04-struct.md
@@ -1,17 +1,30 @@
 1. Définir un struct `Car` selon les instructions suivantes :
+        a. Champs : `brand`, `model` et `year`
+        b. Méthode : `car_age` permettant de calculer l’âge de la voiture (en lui donnant une année en argument)
+        c. [Optionnel] Créer le contructeur (Méthode associée `new`)
+        d. [Optionnel] Créer la méthode `describe` qui formate une chaîne de caractères pour décrire l'instance du struct (ex : « In 1998, Fiat created the Multipla »)
 
-        a. Champs : `make` (marque), `model` et `year`
+2. Écrire un programme permettant de créer une instance du struct `Car` et affichant l’âge de la voiture dans la console
 
-        b. Méthode : `car_age` permettant de calculer l’âge de la voiture
+3. Définir une fonction `is_classic` qui retourne une `Option` pour vérifier si la voiture est ancienne (+ de 10 ans)… peut-être utiliser `car_age` dans la fonction ;)
 
+4. Compléter le programme en incorporant un appel à la fonction `is_classic` (avec l'année actuelle comme argument)
 
-2. Ecrire un programme permettant de créer une instance du struct `Car` et affichant l’âge de la voiture dans la console
+5. Modifier l'année actuelle (dans l'appel de `is_classic`) par `1900`… Que se passe-t-il ?
 
+        → Le programme panique ! Rust rencontre une situation qu'il ne peut
+        pas gérer correctement : (ici) convertir un nombre négatif (`1900 - 1998`) en type `u32` (_unsigned_).  
+        En mode _Debug_, le programme se termine avec un message d'erreur.
 
-3. Définir une fonction `is_classic` qui retourne une `Option` pour vérifier si la voiture est ancienne (+ de 10 ans)
+6. Corriger la méthode `car_age` : elle doit retourner un `Result` :
+        - l'âge de la voiture si celui-ci est positif
+        - une erreur ("Current year cannot be less than the car's year of manufacture.") sinon
 
+7. Transformer la méthode `is_classic` pour utiliser directement ce Résult et renvoyer un `Result<bool, String>` grâce à l'opérateur `?`
 
-4. Définir une fonction `start_car` qui retourne un `Result` pour démarrer la voiture, avec une erreur si la voiture ne peut pas démarrer (par exemple, batterie déchargée)
-
-
-5. Compléter le programme en incorporant des appels aux fonctions `is_classic` et `start_car`
+        > **ASTUCE** dans le `Ok` retourné par `is_classic`,
+        > vous pouvez transmettre une condition…  
+        > Celle-ci sera gérée dans le `match` grâce à :
+        >   - `Ok(true)`
+        >   - `Ok(false)`
+        >   - `Err(e)`


### PR DESCRIPTION
**Proposition pour :**

- remplacer `make` par `brand`
- préciser que `car_age` prend un paramètre
- utiliser un constructeur [optionnel]
- utiliser `format!()` [optionnel]
- au lieu de `start_car` pour travailler les Result, gérer l'erreur quand la date passée est antérieure à l'année de la voiture
  - permet de voir une panique
  - permet de voir les `Result<bool, T>` → il faut `Ok(true)` ET `Ok(false)`
  - permet de travailler sur la gestion automatique d'erreur et l'opérateur `?`
  
  **Inconvénients/Craintes :**
  
  - à la fin, risque de ne plus avoir d'`Option`
  - complique trop l'exercice ?
  
  Si cette PR est acceptée, je me chargerai de modifier les slides en conséquence…