### PR TITLE
07 workspace dep

### DIFF
--- a/corrections/07-workspace/Cargo.toml
+++ b/corrections/07-workspace/Cargo.toml
@@ -1,17 +1,6 @@
-[package]
-name = "workspace"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-math_operations = { path = "./math_operations" }
-
 [workspace]
 members = [
-   "math_operations",
-   "app"
+  "app",
+  "math_operations",
 ]
-
-[[bin]]
-name = "app"
-path = "app/src/main.rs"
+resolver = "2"

--- a/corrections/07-workspace/app/Cargo.toml
+++ b/corrections/07-workspace/app/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+math_operations = { path = "../math_operations" }


### PR DESCRIPTION
Dans la documentation et selon ce que j'ai pu comprendre :

on initialise un workspace avec un `Cargo.toml` sans `[package]` ni rien d'autre que `[workspace]`…

Si notre crate binaire dépend d'une crate de bibliothèque, on ajoute cette dernière comme dépendance de la crate binaire : 
ainsi la dépendance se fait au niveau de chaque crate, ce qui permet une meilleure maintenabilité, de meilleure performance (on ne charge pas inutilement des dépendances si une crate n'en a pas besoin)…

De plus, ça évite de devoir « transformer » le workspace avec des pratiques « peu courantes » (a priori, je n'ai pas le recul) en ajoutant `[package]`, `[dependencies]` et `[[bin]]`